### PR TITLE
chore: add infosec badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![scorecard-score](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/SpiffWorkflow/maturity_score.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/SpiffWorkflow)
+[![scorecard-status](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/SpiffWorkflow/scorecard_status.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/SpiffWorkflow)
 ## SpiffWorkflow
 ![Logo](./graphics/logo_med.png)
 


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Ensure Octoguard badges exist on the Github repository
# Why?
 - This should give owners more visibiilty into this project's security posture